### PR TITLE
Updated Registration shortcuts to be Class Methods

### DIFF
--- a/CoreMeta/CoreMeta/Categories/NSObject+IOC.h
+++ b/CoreMeta/CoreMeta/Categories/NSObject+IOC.h
@@ -36,12 +36,12 @@
 -(void) removeFromIOC;
 
 #pragma mark - Registration Shortcuts
--(void) registerClass;
--(void) registerClassAndCache: (BOOL) cache;
--(void) registerClassAndCache: (BOOL) cache onCreate: (void(^)(id)) onCreate;
--(void) registerClassForClass: (Class) overrideClass;
--(void) registerClassForClass: (Class) overrideClass cache: (BOOL) cache;
--(void) registerClassForProtocol: (Protocol*) protocol;
--(void) registerClassForProtocoal: (Protocol*) protocol cache: (BOOL) cache;
++(void) registerClass;
++(void) registerClassAndCache: (BOOL) cache;
++(void) registerClassAndCache: (BOOL) cache onCreate: (void(^)(id)) onCreate;
++(void) registerClassForClass: (Class) overrideClass;
++(void) registerClassForClass: (Class) overrideClass cache: (BOOL) cache;
++(void) registerClassForProtocol: (Protocol*) protocol;
++(void) registerClassForProtocoal: (Protocol*) protocol cache: (BOOL) cache;
 
 @end

--- a/CoreMeta/CoreMeta/Categories/NSObject+IOC.m
+++ b/CoreMeta/CoreMeta/Categories/NSObject+IOC.m
@@ -64,31 +64,31 @@
 }
 
 #pragma mark - Registration Shortcuts
--(void) registerClass {
++(void) registerClass {
     [[Container sharedContainer] registerClass: [self class]];
 }
 
--(void) registerClassAndCache: (BOOL) cache {
++(void) registerClassAndCache: (BOOL) cache {
     [[Container sharedContainer] registerClass: [self class] cache: YES];
 }
 
--(void) registerClassAndCache: (BOOL) cache onCreate: (void (^)(id)) onCreate {
++(void) registerClassAndCache: (BOOL) cache onCreate: (void (^)(id)) onCreate {
     [[Container sharedContainer] registerClass: [self class] cache: YES onCreate: onCreate];
 }
 
--(void) registerClassForClass: (Class) overrideClass {
++(void) registerClassForClass: (Class) overrideClass {
     [[Container sharedContainer] registerClass: [self class] forClass: overrideClass];
 }
 
--(void) registerClassForClass: (Class) overrideClass cache: (BOOL) cache {
++(void) registerClassForClass: (Class) overrideClass cache: (BOOL) cache {
     [[Container sharedContainer] registerClass: [self class] forClass: overrideClass cache: cache];
 }
 
--(void) registerClassForProtocol: (Protocol*) protocol {
++(void) registerClassForProtocol: (Protocol*) protocol {
     [[Container sharedContainer] registerClass: [self class] forProtocol: protocol];
 }
 
--(void) registerClassForProtocoal: (Protocol*) protocol cache: (BOOL) cache {
++(void) registerClassForProtocoal: (Protocol*) protocol cache: (BOOL) cache {
     [[Container sharedContainer] registerClass: [self class] forProtocol: protocol cache: cache];
 }
 


### PR DESCRIPTION
Updated the registration shortcuts within NSObject+IOC to be class methods vs. instance methods.

Josh - please review as I "believe" this was your original intent - but I wanted to make sure.

Basically - I "believe" that the shortcuts existed to make the container configuration cleaner to read. (Correct?).

---

Example (Old):
    // base config
    Container\* container = [Container sharedContainer];
    [container addConvention: [IdiomContainerConvention convention]];

```
// services
[container registerClass: [JsonCerealizer class] forProtocol: @protocol(Cerealizer)];
[container registerClass: [JsonCerealizer class]];

[container registerClass:[WineXChgHttpService class] forClass:[HttpService class]];

[container registerClass:[ODataClient class] cache:YES onCreate:^(ODataClient* client) {
    client.baseUrl = [Constants oDataUrl];
}];

[container registerClass:[ApiHttpService class] cache:YES onCreate:^(ApiHttpService* service) {
    service.baseUrl = [Constants apiUrl];
}];

[container registerClass:[UserService class]];
[container registerClass:[ImageManager class]];
```

---

Example (New):

```
// base config
[[Container sharedContainer] addConvention:[IdiomContainerConvention convention]];

// services
[JsonCerealizer registerClassForProtocol:@protocol(Cerealizer)];
[JsonCerealizer registerClass];

[WineXChgHttpService registerClassForClass:[HttpService class]];

[ODataClient registerClassAndCache:YES onCreate:^(ODataClient* client) {
    client.baseUrl = [Constants oDataUrl];
}];

[ApiHttpService registerClassAndCache:YES onCreate:^(ApiHttpService* service) {
    service.baseUrl = [Constants apiUrl];
}];

[UserService registerClass];

[ImageManager registerClassAndCache:YES];
```

Thanks,
Scott M.
