### PR TITLE
Added an option to perform a block on a main thread and wait

### DIFF
--- a/CoreMeta/CoreMeta/Categories/NSObject+Perform.h
+++ b/CoreMeta/CoreMeta/Categories/NSObject+Perform.h
@@ -25,6 +25,7 @@
 
 -(void) performBlock: (void (^)(void)) block afterDelay:(NSTimeInterval)delay;
 -(void) performBlockInMainThread: (void (^)(void)) block;
+-(void) performBlockInMainThreadAndWait: (void (^)(void)) block;
 -(void) performBlockInBackground: (void (^)(void)) block;
 
 -(void) performSelectorInBackground: (SEL) selector withObject: (id) object afterDelay: (NSTimeInterval) delay;

--- a/CoreMeta/CoreMeta/Categories/NSObject+Perform.m
+++ b/CoreMeta/CoreMeta/Categories/NSObject+Perform.m
@@ -32,6 +32,13 @@
     dispatch_async(dispatch_get_main_queue(), block);
 }
 
+-(void) performBlockInMainThreadAndWait: (void (^)(void)) block {
+    if ([NSThread isMainThread])
+        block();
+    else
+        dispatch_sync(dispatch_get_main_queue(), block);
+}
+
 -(void) performBlockInBackground: (void (^)(void)) block {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), block);
 }


### PR DESCRIPTION
I was sending a delegate call from a background thread that would update the UI.  If another update came in before the UI was updated the UICollectionView would throw and exception because the count changed on it unexpectedly.   This allows the background thread to wait for the UI to update before moving on.
