### PR TITLE
Added support for BOOL types to reflection

### DIFF
--- a/CoreMeta/CoreMeta/Meta/Reflection.m
+++ b/CoreMeta/CoreMeta/Meta/Reflection.m
@@ -55,10 +55,11 @@
                 @"Tc" : @"char",
                 @"Td" : @"double",
                 @"Tl" : @"long",
-                @"Ts" : @"short"
+                @"Ts" : @"short",
+                @"TB" : @"bool",
             };
             
-            sharedReflectionInstance.ivarValueTypeList = @[ @"float", @"int", @"char", @"double",@"long",@"short", @"f", @"i", @"c", @"d",@"l",@"s", @"@?", @"?"];
+            sharedReflectionInstance.ivarValueTypeList = @[ @"float", @"int", @"char", @"double", @"long", @"short", @"bool", @"f", @"i", @"c", @"d", @"l" ,@"s", @"B", @"@?", @"?"];
             
             sharedReflectionInstance.ignoreClasses = @[ [NSObject class], [UIViewController class], [UIView class], [UITableViewCell class] ];
             


### PR DESCRIPTION
In 64 bit iOS builds BOOL is typedefs to the C99 bool type rather than char.  So BOOL values now have a unique type code of B.
