### PR TITLE
CoreMeta would not build unless the project included CoreData

### DIFF
--- a/CoreMeta/CoreMeta.xcodeproj/project.pbxproj
+++ b/CoreMeta/CoreMeta.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		8C14305B15B4A04500A9C1B9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/CoreMeta.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CoreMeta/CoreMeta-Prefix.pch";
@@ -471,6 +472,7 @@
 		8C14305C15B4A04500A9C1B9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/CoreMeta.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CoreMeta/CoreMeta-Prefix.pch";

--- a/CoreMeta/CoreMeta/Meta/Reflection.m
+++ b/CoreMeta/CoreMeta/Meta/Reflection.m
@@ -26,7 +26,7 @@
 #import "NSObject+IOC.h"
 #import "NSObject+Properties.h"
 #import "NSString+Helpers.h"
-#import <CoreData/CoreData.h>
+@import CoreData;
 
 #pragma mark - Private Category
 @interface Reflection() 


### PR DESCRIPTION
I enabled modules in the project settings and added an import of CoreData.

I am guessing we have never seen this before because projects come with CoreData by default normally?
