### PR TITLE
Add missing Foundation import and run onCreate for protocol resolved objects

### DIFF
--- a/CoreMeta/CoreMeta/Categories/NSObject+IOC.h
+++ b/CoreMeta/CoreMeta/Categories/NSObject+IOC.h
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 
 
 @interface NSObject (IOC)

--- a/CoreMeta/CoreMeta/IOC/Container.m
+++ b/CoreMeta/CoreMeta/IOC/Container.m
@@ -248,8 +248,14 @@
 -(instancetype) objectForProtocol: (Protocol*) protocol {
     // check explicit map
     RegistryMap* map = [self getMapRegisteredForProtocol: protocol];
-    if (map)
-        return [self objectForClass: map.classType cache: map.cache];
+    
+    if (map) {
+        id obj = [self objectForClass: map.classType cache: map.cache];
+        if (map.onCreate) {
+            map.onCreate(obj);
+        }
+        return obj;
+    }
 
     // check conventions
     for (ContainerConvention* convention in conventions) {


### PR DESCRIPTION
The missing import made the code not build when added to a Swift project. I have also added an onCreate call that was missing when resolving objects for a protocol.