### PR TITLE
Fixed issue where injecting a view controller would trap

### DIFF
--- a/CoreMeta/CoreMeta/Meta/CMTypeIntrospector.swift
+++ b/CoreMeta/CoreMeta/Meta/CMTypeIntrospector.swift
@@ -85,6 +85,9 @@ public class CMTypeIntrospector {
     }
 
     private func parseRefTypeInfo(typename: String) -> CMTypeInfo {
+        guard typename.characters.count > 3
+            else { return CMTypeInfo(name: typename, isKnown: false, isValueType: false, isProtocol: false) }
+        
         let name = typename.substringWithRange(Range(start: typename.startIndex.advancedBy(3), end: typename.endIndex.advancedBy(-1)));
 
         return CMTypeInfo(name: name, isKnown: true, isValueType: false, isProtocol: false)
@@ -111,6 +114,6 @@ public class CMTypeIntrospector {
     }
 
     private func isProtocol(typename: String) -> Bool {
-        return typename.substringFromIndex(typename.startIndex.advancedBy(3)).hasPrefix("<")
+        return typename.characters.count > 3 && typename.substringFromIndex(typename.startIndex.advancedBy(3)).hasPrefix("<")
     }
 }


### PR DESCRIPTION
In some cases "@T" was the typename and the app would trap because it would try to access out of bounds characters