### PR TITLE
Fixed syntax issue where it looked like we were not registering a cla…

### DIFF
--- a/CoreMeta/CoreMeta/Extensions/CMNSObjectExtensionForContainer.swift
+++ b/CoreMeta/CoreMeta/Extensions/CMNSObjectExtensionForContainer.swift
@@ -62,11 +62,11 @@ public extension NSObject {
         CMStaticContainer.container.registerClass(self)
     }
 
-    public class func register(cache: Bool) {
+    public class func register(andCache cache: Bool) {
         CMStaticContainer.container.registerClass(self, cache: cache)
     }
 
-    public class func register(cache: Bool, onCreate: (NSObject) -> Void) {
+    public class func register(andCache cache: Bool, onCreate: (NSObject) -> Void) {
         CMStaticContainer.container.registerClass(self, cache: cache, onCreate: onCreate)
     }
 


### PR DESCRIPTION
…ss by calling method ".regiser(false)"

**Real nitpick here** but it didn't read well to me as .register(false/true) when the bool is determining caching.

It now would read .register(andCache: true). The old .register() syntax stays.