### PR TITLE
Updated the generator function support for Swift 3.0

### DIFF
--- a/CoreMeta/CoreMeta/IOC/CMContainer.swift
+++ b/CoreMeta/CoreMeta/IOC/CMContainer.swift
@@ -189,8 +189,10 @@ open class CMContainer : NSObject, CMContainerProtocol {
         let typeString = String(reflecting: type)
 
         // Captures a type name from statements like
-        // "Swift.Optional<() -> Swift.String>" and "() -> Swift.String"
-        let regex = try! NSRegularExpression(pattern: "(?:Swift.Optional\\<)?\\(\\) -> ([^>]*)(?:\\>)?", options: NSRegularExpression.Options(rawValue: 0))
+        // "Swift.ImplicitlyUnwrappedOptional<(()) -> Swift.String>",
+        // "Swift.Optional<() -> Swift.String>", and
+        //  "() -> Swift.String"
+        let regex = try! NSRegularExpression(pattern: ".*\\(+\\)+ -> ([^>]*)", options: NSRegularExpression.Options(rawValue: 0))
         
         let matches = regex.matches(in: typeString, options: .withTransparentBounds, range: NSMakeRange(0, typeString.characters.count))
         if let match = matches.first {


### PR DESCRIPTION
Had to update the Regex that matches the reflected closure string.
Hopefully it's specific enough not to match anything else.